### PR TITLE
Tests if settimeout is called with the expected args

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -66,5 +66,22 @@ describe('periodicPromise', () => {
         done();
       });
     });
+
+    it('calls set timeout twice with 10ms when provided a 10ms delay', (done) => {
+      expect.assertions(3);
+     
+      const callback = jest.fn().mockName('callback').mockReturnValue(true)
+      const action = jest.fn().mockName('action').mockReturnValue(true);
+      const setTimeoutfn = jest.spyOn(global,'setTimeout');
+
+      const executionTimes = 3;
+
+      periodicPromise(10, action, callback, executionTimes).then(() => {
+        expect(callback).toBeCalledTimes(3);
+        expect(setTimeoutfn).toHaveBeenNthCalledWith(1,expect.any(Function), 10);
+        expect(setTimeoutfn).toHaveBeenNthCalledWith(2,expect.any(Function), 10);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
Added a unit test that simply tests that setTimeout was called with the correct number of milliseconds as the timeout. This works by spying on the global setTimeout function and verifying a callback was provided and asserting that the second parameter is as expected for the two calls that were made.

I tried to use jest.useFakeTimers() but that didn't work because I couldn't figure out how to progress the time forward only when a timer was in the queue and so I had to call jest.advanceTimersByTime() several times. If we could get it working that would be a more elegant solution but for now just checking that the proper timeouts were called should be good enough.